### PR TITLE
Feature/3 로그인 페이지 뷰 제작

### DIFF
--- a/frontend/src/Login/LoginBox.scss
+++ b/frontend/src/Login/LoginBox.scss
@@ -1,0 +1,65 @@
+.LoginSection {
+  display: flex;
+  height: 100vh;
+}
+
+.LoginBox {
+  display: flex;
+  width: 50%;
+  flex-direction: column;
+  box-sizing: border-box;
+  padding: 5vh 7.5vw 5vh 15vw;
+
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 5vh 0;
+  }
+
+  .LoginTransferMessage {
+    display: flex;
+    color: gray;
+    font-size: 0.75rem;
+    text-align: center;
+    align-items: center;
+  }
+  .LoginTransferMessage::before {
+    content: "";
+    box-sizing: border-box;
+    margin-right: 1rem;
+    flex-grow: 1;
+    background-color: lightgray;
+    height: 1px;
+  }
+  .LoginTransferMessage::after {
+    content: "";
+    box-sizing: border-box;
+    margin-left: 1rem;
+    flex-grow: 1;
+    background-color: lightgray;
+    height: 1px;
+  }
+
+  .LoginSuggestion {
+    color: gray;
+    font-size: 0.75rem;
+    font-weight: 500;
+    margin: 0.5rem 0;
+
+    a {
+      margin-left: 1em;
+      color: turquoise;
+    }
+  }
+}
+
+.LoginImage {
+  flex-grow: 1;
+  background-image: url("https://tumblbug-assets.s3.ap-northeast-1.amazonaws.com/static_assets/login/bg_login_email.jpg");
+  background-size: cover;
+}
+.LoginImageKakao {
+  flex-grow: 1;
+  background-image: url("https://tumblbug-assets.s3.ap-northeast-1.amazonaws.com/static_assets/login/bg_login_kakao.jpg");
+  background-size: cover;
+}

--- a/frontend/src/Login/LoginBox.tsx
+++ b/frontend/src/Login/LoginBox.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import Logo from "../TumblbugLogo/Logo";
+import LoginForm from "./LoginForm/LoginForm";
+import LoginFormKakao from "./LoginFormKakao/LoginFormKakao";
+import LoginTransfer from "./LoginTransfer/LoginTransfer";
+import "./LoginBox.scss";
+
+function LoginBox() {
+  return (
+    // 이메일로 로그인을 위한 부분
+    // <section className="LoginSection">
+    //   <section className="LoginBox">
+    //     <Logo />
+    //     <h2 className="LoginTitle">이메일로 로그인</h2>
+    //     <LoginForm />
+    //     <p className="LoginTransferMessage">다른 방법으로 로그인</p>
+    //     <LoginTransfer />
+    //     <p className="LoginSuggestion">
+    //       아직 텀블벅 계정이 없으신가요?
+    //       <a href="https://www.google.co.kr">회원가입</a>
+    //     </p>
+    //     <p className="LoginSuggestion">
+    //       혹시 비밀번호를 잊으셨나요?
+    //       <a href="https://www.google.co.kr">비밀번호 재설정</a>
+    //     </p>
+    //   </section>
+    //   <div className="LoginImage" />
+    // </section>
+
+    // 카카오로 로그인을 위한 부분
+    <section className="LoginSection">
+      <section className="LoginBox">
+        <Logo />
+        <h2 className="LoginTitle">카카오로 로그인</h2>
+        <LoginFormKakao />
+        <p className="LoginTransferMessage">다른 방법으로 로그인</p>
+        <LoginTransfer />
+
+        <p className="LoginSuggestion">
+          아직 텀블벅 계정이 없으신가요?
+          <a href="https://www.google.co.kr">회원가입</a>
+        </p>
+      </section>
+      <div className="LoginImageKakao" />
+    </section>
+  );
+}
+
+export default LoginBox;

--- a/frontend/src/Login/LoginFormKakao/LoginFormKakao.scss
+++ b/frontend/src/Login/LoginFormKakao/LoginFormKakao.scss
@@ -1,0 +1,43 @@
+.LoginFormKakao {
+  margin-bottom: 5em;
+  * {
+    margin: 0.5rem 0;
+  }
+
+  p {
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  input {
+    width: 100%;
+    height: 3em;
+  }
+
+  .LoginEmailInput {
+    display: flex;
+    align-items: center;
+
+    input {
+      flex-grow: 1;
+      margin-right: 1rem;
+    }
+    span {
+      white-space: nowrap;
+    }
+  }
+
+  button {
+    display: flex;
+    background-color: #fee500;
+    color: #000;
+    align-items: center;
+    justify-content: center;
+    font-size: 1em;
+    font-weight: 700;
+    cursor: pointer;
+    width: 100%;
+    height: 3em;
+    border: none;
+  }
+}

--- a/frontend/src/Login/LoginFormKakao/LoginFormKakao.tsx
+++ b/frontend/src/Login/LoginFormKakao/LoginFormKakao.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import "./LoginFormKakao.scss";
+
+function LoginFormKakao() {
+  return (
+    <form className="LoginFormKakao">
+      <div>
+        <label htmlFor="kakaoemail">
+          <p className="LoginLabel">카카오 메일</p>
+          <div className="LoginEmailInput">
+            <input
+              type="text"
+              id="kakaoemail"
+              className="LoginInput"
+              placeholder="카카오 아이디를 입력해주세요"
+            />
+            <span className="LoginLabelKakao">@ kakao.com</span>
+          </div>
+        </label>
+      </div>
+      <div>
+        <label htmlFor="password">
+          <p className="LoginLabel">비밀번호</p>
+          <input
+            type="password"
+            id="password"
+            className="LoginInput"
+            placeholder="비밀번호를 입력해주세요"
+          />
+        </label>
+      </div>
+      <button type="submit" className="LoginButtonKakao">
+        <svg width="34" height="34" viewBox="0 0 34 34" fill="none">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M17.0002 9.03125C12.0901 9.03125 8.146 12.0938 8.146 15.8415C8.30698 18.4205 9.91683 20.6369 12.2511 21.604L11.4059 24.6666C11.3657 24.7472 11.4059 24.8681 11.4864 24.908C11.5669 24.989 11.7279 24.989 11.8084 24.908L15.3903 22.5309C15.9135 22.6115 16.4367 22.6518 17.0002 22.6518C21.87 22.6518 25.8543 19.5892 25.8543 15.8415C25.8543 12.0938 21.9102 9.03125 17.0002 9.03125Z"
+            fill="black"
+            fillOpacity="0.9"
+          />
+        </svg>
+        카카오로 로그인
+      </button>
+    </form>
+  );
+}
+
+export default LoginFormKakao;

--- a/frontend/src/Login/LoginTransfer/LoginTransfer.scss
+++ b/frontend/src/Login/LoginTransfer/LoginTransfer.scss
@@ -1,0 +1,8 @@
+.LoginTransferIcons {
+  margin: 1rem 0 2rem;
+
+  svg {
+    cursor: pointer;
+    margin-right: 1em;
+  }
+}

--- a/frontend/src/Login/LoginTransfer/LoginTransfer.tsx
+++ b/frontend/src/Login/LoginTransfer/LoginTransfer.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import "./LoginTransfer.scss";
+
+function LoginTransfer() {
+  return (
+    <section className="LoginTransferIcons">
+      <svg width="34" height="34" viewBox="0 0 34 34" fill="none">
+        <circle cx="17" cy="17" r="14.875" fill="#FEE500" />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M17.0002 9.03125C12.0901 9.03125 8.146 12.0938 8.146 15.8415C8.30698 18.4205 9.91683 20.6369 12.2511 21.604L11.4059 24.6666C11.3657 24.7472 11.4059 24.8681 11.4864 24.908C11.5669 24.989 11.7279 24.989 11.8084 24.908L15.3903 22.5309C15.9135 22.6115 16.4367 22.6518 17.0002 22.6518C21.87 22.6518 25.8543 19.5892 25.8543 15.8415C25.8543 12.0938 21.9102 9.03125 17.0002 9.03125Z"
+          fill="black"
+          fillOpacity="0.9"
+        />
+      </svg>
+      <svg width="34" height="34" viewBox="0 0 34 34" fill="none">
+        <circle cx="17" cy="17" r="14.875" fill="#D0D0D0" />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M24.5557 10.8608H9.44458V12.0886H24.5557V10.8608ZM24.5557 12.0887L17.0001 17.8183L9.44458 12.0887H24.5557Z"
+          fill="white"
+        />
+        <path
+          d="M20.1483 16.9997L24.5557 20.2737L24.5557 13.7256L20.1483 16.9997Z"
+          fill="white"
+        />
+        <path
+          d="M13.852 16.9997L9.44458 20.2737L9.44458 13.7256L13.852 16.9997Z"
+          fill="white"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M17.0001 19.4554L19.1589 17.8184L24.5557 21.9109L24.5557 23.1387H9.44458V21.9109L14.8414 17.8184L17.0001 19.4554Z"
+          fill="white"
+        />
+      </svg>
+    </section>
+  );
+}
+
+export default LoginTransfer;

--- a/frontend/src/Main/Main.tsx
+++ b/frontend/src/Main/Main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Navbar from "../Navbar/Navbar";
 import Body from "./Body";
 import Footer from './Footer';
+import LoginBox from "../Login/LoginBox";
 import "./main.scss";
 
 function Main() {
@@ -13,5 +14,13 @@ function Main() {
     </section>
   );
 }
+
+// function Login() {
+//   return (
+//     <section className="main">
+//       <LoginBox />
+//     </section>
+//   );
+// }
 
 export default Main;

--- a/frontend/src/Main/main.scss
+++ b/frontend/src/Main/main.scss
@@ -1,5 +1,5 @@
 .main {
-  width: 96vw;
+  width: 100vw;
   margin: 0 auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
## 이슈 번호 : #3 


## PR 유형
- feature 추가

## 작업 내용
- 이메일 사용 로그인 뷰 퍼블리싱
![image](https://user-images.githubusercontent.com/45064913/234023532-7955c597-353f-4e2c-b212-39f7ac8ef274.png)

- 카카오 Oauth 로그인 뷰 퍼블리싱
![image](https://user-images.githubusercontent.com/45064913/234023181-048f271a-284a-486b-bfa8-a413ea0c8831.png)


## 리뷰어가 집중해야 될 부분
- SCSS 문법 사용 중 불필요한 부분, 의문스러운 부분이 있으면 말씀해주세요
- 이메일로 로그인, 카카오로 로그인 총 2개의 로그인 뷰가 제작되었습니다. 잘 확인해주세요.
- 로컬 환경에서 의도대로 동작하지 않는다면 말씀해주세요

## 다음 작업 계획
- 회원가입 페이지 뷰 제작

## 기타 사항
- 로그인 페이지를 확인하려면 'Main/Main.tsx'에서 `<LoginBox />`를 출력해야 합니다.
- 이메일로 로그인 페이지, 카카오로 로그인 페이지 뷰를 보려면 'Login/LoginBox.tsx'에서 `// 이메일로 로그인을 위한 부분` 아래 부분 또는 `// 카카오로 로그인을 위한 부분` 아래를 주석 처리 해제해주셔야 합니다.