### PR TITLE
feat:81 - Implement upload'image drag & drop event

### DIFF
--- a/frontend/src/ProjectUpload/ProjectUpload.tsx
+++ b/frontend/src/ProjectUpload/ProjectUpload.tsx
@@ -1,17 +1,60 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ProjectRegisterColumn from "./Register/ProjectRegisterColumn";
-import "./projectUpload.scss";
 import ProjectPreviewColumn from "./Preview/ProjectPreviewColumn";
 import CategorySelectModal from './Register/CategorySelectModal';
 import CardAddModal from './Register/CardAddModal';
+import { $, changeCSS } from '../utils/commonFunction';
+import { updatePreviewThumbNail } from './Preview/PreviewSummary';
+import "./projectUpload.scss";
 
 function ProjectUpload() {
+  useEffect(() => {
+    const $projectUploadContainer = $(".projectUpload") as HTMLElement;
+    const $projectUploadModal = $(".projectUploadModal") as HTMLElement;
+
+    $projectUploadModal.addEventListener("dragleave", (event) => {
+      changeCSS($projectUploadModal, "display", "none");
+    })
+
+    $projectUploadContainer.addEventListener("dragover", (event) => {
+      // prevent downloading files
+      event.preventDefault();
+      changeCSS($projectUploadModal, "display", "block");
+    });
+
+    $projectUploadContainer.addEventListener("drop", (event) => {
+      // prevent open files
+      event.preventDefault();
+      changeCSS($projectUploadModal, "display", "none");
+
+      const imageTypeReg = /\.(jpg|jpeg|png|gif)$/i
+      const file = event.dataTransfer?.files[0];
+      
+      if(file && imageTypeReg.test(file.name)) {
+        const dropFileReader = new FileReader();
+
+        dropFileReader.onload = (e) => {
+          const fileName = file.name;
+          const imageLink = e.target?.result as string;
+
+          const $thumbNailInput = $(".imageLinkRow > input") as HTMLInputElement;
+          $thumbNailInput.value = fileName;
+          updatePreviewThumbNail(imageLink);
+        }
+
+        dropFileReader.readAsDataURL(file);
+      }
+    })
+
+  }, []);
+
   return (
     <section className="projectUpload">
       <ProjectRegisterColumn />
       <ProjectPreviewColumn />
       <CategorySelectModal />
       <CardAddModal/>
+      <section className="projectUploadModal"> </section>
     </section>
   );
 }

--- a/frontend/src/ProjectUpload/projectUpload.scss
+++ b/frontend/src/ProjectUpload/projectUpload.scss
@@ -5,4 +5,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  & .projectUploadModal {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100vw;
+    height: 100vh;
+    // transition: 0.3s;
+    background-color: rgba(0, 0, 0, 0.3);
+  }
 }


### PR DESCRIPTION
## 이슈 번호 : #81 프로젝트 업로드 이미지 drag & drop 구현


## PR 유형
- feature 추가

## 작업 내용
- drag & drop 이미지 preview 이벤트 구현

https://github.com/Start-as-Web-Developers/tumblbug-clone-coding/assets/74173976/941bd5b2-962b-439d-b7f9-5df2239375e3

- drag leave 감지 이벤트 구현

https://github.com/Start-as-Web-Developers/tumblbug-clone-coding/assets/74173976/917c758b-4c70-453f-afa3-dd5b24cd69ef


## 리뷰어가 집중해야 될 부분
- drag & drop 구현 방식이 궁금하다면 말씀해주세요.
- modal code의 위치가 적절하지 않다면 제안해주세요.

## 다음 작업 계획
- drag & drop 구현 방식 정리