### PR TITLE
Feature/84 modify user logic

### DIFF
--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/Exception/userexception/WrongPasswordException.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/Exception/userexception/WrongPasswordException.java
@@ -1,0 +1,11 @@
+package com.example.tumblbugclone.Exception.userexception;
+
+public class WrongPasswordException extends Exception{
+    public WrongPasswordException() {
+        super();
+    }
+
+    public WrongPasswordException(String message) {
+        super(message);
+    }
+}

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UserController.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UserController.java
@@ -29,24 +29,15 @@ public class UserController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
+
     @PostMapping
     @Transactional
     public ResponseEntity signUp(@RequestBody UserDTO newUserDTO){
 
-        User user = null;
         HttpHeaders errorHeader = new HttpHeaders();
 
         try{
-            user = convertUserDTO2User(newUserDTO);
-        } catch (UserDTOConvertException e) {
-            errorHeader.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, e.getMessage());
-            return ResponseEntity.badRequest()
-                    .headers(errorHeader)
-                    .body("");
-        }
-
-        try{
-            userService.join(user);
+            userService.join(newUserDTO);
         }catch (UserIdDuplicatedException e){
             errorHeader.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, HttpConst.DUPLICATED_USER_ID_MESSAGE);
             return ResponseEntity.badRequest()
@@ -57,31 +48,31 @@ public class UserController {
             return ResponseEntity.badRequest()
                     .headers(errorHeader)
                     .body("");
-        }
-
-        return new ResponseEntity(HttpStatus.OK);
-    }
-
-
-
-    @PatchMapping("/{userIdx}")
-    public ResponseEntity update(@PathVariable String userIdx, @RequestBody UserDTO modifiedUserDTO){
-
-        User modifiedUser;
-        HttpHeaders errorHeader = new HttpHeaders();
-        try {
-            modifiedUser = convertUserDTO2User(modifiedUserDTO);
-        } catch (UserDTOConvertException e) {
+        }catch (UserDTOConvertException e){
             errorHeader.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, e.getMessage());
             return ResponseEntity.badRequest()
                     .headers(errorHeader)
                     .body("");
         }
 
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+
+    @PatchMapping("/{userIdx}")
+    public ResponseEntity update(@PathVariable String userIdx, @RequestBody UserDTO modifiedUserDTO){
+
+        HttpHeaders errorHeader = new HttpHeaders();
+
         try {
-            userService.modify(modifiedUser);
+            userService.modify(modifiedUserDTO);
         } catch (UserCantModifyIdException e) {
             errorHeader.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, HttpConst.CANT_MODIFY_USER_ID_MESSAGE);
+            return ResponseEntity.badRequest()
+                    .headers(errorHeader)
+                    .body("");
+        }catch (UserDTOConvertException e){
+            errorHeader.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, e.getMessage());
             return ResponseEntity.badRequest()
                     .headers(errorHeader)
                     .body("");
@@ -95,9 +86,8 @@ public class UserController {
     public ResponseEntity unregister(@RequestBody UserDTO deleteUser){
 
         HttpHeaders httpHeaders = new HttpHeaders();
-        User user;
         try {
-            user = convertUserDTO2User(deleteUser);
+            userService.unregiste(deleteUser);
         } catch (UserDTOConvertException e) {
             httpHeaders.set(HttpConst.HEADER_NAME_ERROR_MESSAGE, e.getMessage());
             return ResponseEntity.badRequest()
@@ -105,39 +95,10 @@ public class UserController {
                     .build();
         }
 
-        userService.unregiste(user);
 
         return ResponseEntity.ok().build();
     }
 
-
-    private User convertUserDTO2User(UserDTO newUserDTO) throws UserDTOConvertException {
-        User user = new User();
-        user.setUserIdx(newUserDTO.getUserIdx());
-        if(newUserDTO.getUserName() == null){
-            throw new UserDTOConvertException(HttpConst.USERNAME_IS_NULL);
-        }
-        user.setUserName(newUserDTO.getUserName());
-
-        if(newUserDTO.getUserId() == null){
-            throw new UserDTOConvertException(HttpConst.USERID_IS_NULL);
-        }
-        user.setUserId(newUserDTO.getUserId());
-
-        if(newUserDTO.getUserPassword() == null){
-            throw new UserDTOConvertException(HttpConst.USERPASSWORD_IS_NULL);
-        }
-        user.setUserPassword(newUserDTO.getUserPassword());
-
-        if(newUserDTO.getUserPassword() == null){
-            throw new UserDTOConvertException(HttpConst.USEREMAIL_IS_NULL);
-        }
-        user.setUserEmail(newUserDTO.getUserEmail());
-
-        //추가 정보 변환
-
-        return user;
-    }
 
 
     //== 리팩토링 완료 ==//

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
@@ -4,6 +4,8 @@ package com.example.tumblbugclone.service;
 
 import com.example.tumblbugclone.Exception.userexception.*;
 
+import com.example.tumblbugclone.dto.UserDTO;
+import com.example.tumblbugclone.managedconst.HttpConst;
 import com.example.tumblbugclone.model.User;
 import com.example.tumblbugclone.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +21,8 @@ public class UserService {
     public UserService(UserRepository userRepository){this.userRepository = userRepository;}
 
 
-    public long join(User user) throws UserEmailDuplicatedException, UserIdDuplicatedException {
+    public long join(UserDTO userDTO) throws UserEmailDuplicatedException, UserIdDuplicatedException, UserDTOConvertException {
+        User user = convertDTO2User(userDTO);
         try {
             userRepository.checkDuplication(user);
         } catch (UserEmailDuplicatedException | UserIdDuplicatedException e) {
@@ -46,26 +49,29 @@ public class UserService {
     }
 
 
-    public User findUserByIndex(long userIdx){
+    public UserDTO findUserByIndex(long userIdx){
 
         User findUser = userRepository.findUserByIndex(userIdx);
 
-        return findUser;
+        return convertUser2DTO(findUser);
     }
 
-    public User findUserById(String userId){
+    public UserDTO findUserById(String userId){
         User findUser = userRepository.findUserById(userId);
 
-        return findUser;
+        return convertUser2DTO(findUser);
     }
 
-    public void unregiste(User user){
+    public void unregiste(UserDTO userDTO) throws UserDTOConvertException {
+        User user = convertDTO2User(userDTO);
         User findUser = userRepository.findUserByIndex(user.getUserIdx());
         user.setActive(false);
         userRepository.modify(user);
     }
 
-    public void modify(User user) throws UserCantModifyIdException {
+    public void modify(UserDTO userDTO) throws UserCantModifyIdException, UserDTOConvertException {
+        User user = convertDTO2User(userDTO);
+
         User findUser = userRepository.findUserByIndex(user.getUserIdx());
 
         if(findUser.getUserId().equals(user.getUserId()) == false){
@@ -75,6 +81,59 @@ public class UserService {
         userRepository.modify(user);
     }
 
+    public UserDTO convertUser2DTO(User user){
+        UserDTO userDTO = new UserDTO();
+
+        userDTO.setUserId(user.getUserId());
+
+        userDTO.setUserName(user.getUserName());
+
+        userDTO.setUserEmail(user.getUserEmail());
+
+        userDTO.setUserPassword(user.getUserPassword());
+
+        //Idx는??
+        userDTO.setUserIdx(user.getUserIdx());
+        userDTO.setUserImg(user.getUserImg());
+        userDTO.setActive(user.isActive());
+        userDTO.setGreeting(user.getGreeting());
+        userDTO.setLastLogin(user.getLastLogin());
+        //추가 정보 변환
+
+        return userDTO;
+    }
+
+    public User convertDTO2User(UserDTO newUserDTO) throws UserDTOConvertException {
+        User user = new User();
+        user.setUserIdx(newUserDTO.getUserIdx());
+        if(newUserDTO.getUserName() == null){
+            throw new UserDTOConvertException(HttpConst.USERNAME_IS_NULL);
+        }
+        user.setUserName(newUserDTO.getUserName());
+
+        if(newUserDTO.getUserId() == null){
+            throw new UserDTOConvertException(HttpConst.USERID_IS_NULL);
+        }
+        user.setUserId(newUserDTO.getUserId());
+
+        /*password는 null일 수 있음
+        if(newUserDTO.getUserPassword() == null){
+            throw new UserDTOConvertException(HttpConst.USERPASSWORD_IS_NULL);
+        }
+        */
+        user.setUserPassword(newUserDTO.getUserPassword());
+
+        if(newUserDTO.getUserEmail() == null){
+            throw new UserDTOConvertException(HttpConst.USEREMAIL_IS_NULL);
+        }
+        user.setUserEmail(newUserDTO.getUserEmail());
+
+        user.setUserImg(newUserDTO.getUserImg());
+        user.setGreeting(newUserDTO.getGreeting());
+        user.setLastLogin(newUserDTO.getLastLogin());
+        user.setActive(newUserDTO.isActive());
+        return user;
+    }
 
 }
 

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
@@ -2,14 +2,12 @@
 package com.example.tumblbugclone.service;
 
 
-import com.example.tumblbugclone.Exception.userexception.UserCantModifyIdException;
-
-import com.example.tumblbugclone.Exception.userexception.UserEmailDuplicatedException;
-import com.example.tumblbugclone.Exception.userexception.UserIdDuplicatedException;
+import com.example.tumblbugclone.Exception.userexception.*;
 
 import com.example.tumblbugclone.model.User;
 import com.example.tumblbugclone.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,9 +22,28 @@ public class UserService {
     public long join(User user) throws UserEmailDuplicatedException, UserIdDuplicatedException {
         try {
             userRepository.checkDuplication(user);
-        }catch (UserEmailDuplicatedException | UserIdDuplicatedException e){
+        } catch (UserEmailDuplicatedException | UserIdDuplicatedException e) {
             throw e;
         }
+        long savedIndex = userRepository.save(user);
+
+        return savedIndex;
+    }
+
+    public long login(String userId, String userPassword) throws UserCantFindException, WrongPasswordException {
+        User userById;
+        try {
+            userById = userRepository.findUserById(userId);
+        }catch (EmptyResultDataAccessException e){
+            throw new UserCantFindException();
+        }
+
+        if(userById.getUserPassword().equals(userPassword) == false){
+            throw new WrongPasswordException();
+        }
+
+        return userById.getUserIdx();
+    }
 
 
     public User findUserByIndex(long userIdx){

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UserControllerTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.tumblbugclone.controller;
 
 import com.example.tumblbugclone.Exception.userexception.UnregisterUserException;
+import com.example.tumblbugclone.dto.UserDTO;
 import com.example.tumblbugclone.managedconst.HttpConst;
 import com.example.tumblbugclone.model.User;
 import com.example.tumblbugclone.repository.UserRepository;
@@ -43,11 +44,10 @@ public class UserControllerTest {
         //given
         this.mockMvc.perform(get(HttpConst.USER_URI)).andExpect(status().isOk());
     }
-
     @Test
     @Transactional
     public void 빈_DB_회원가입_동작_테스트() throws Exception{
-        User user1 = make_Nth_User(1);
+        UserDTO user1 = make_Nth_User(1);
 
         mockMvc.perform(post(HttpConst.USER_URI)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -62,11 +62,11 @@ public class UserControllerTest {
     public void 중복_Id_테스트_inWeb() throws Exception{
 
         //given
-        User user1 = make_Nth_User(1);
+        UserDTO user1 = make_Nth_User(1);
         userService.join(user1);
 
         //when
-        User user2 = make_Nth_User(2);
+        UserDTO user2 = make_Nth_User(2);
         user2.setUserId(user1.getUserId());
 
         //then
@@ -83,11 +83,11 @@ public class UserControllerTest {
     public void 중복_Email_테스트_inWeb() throws Exception{
 
         //given
-        User user1 = make_Nth_User(1);
+        UserDTO user1 = make_Nth_User(1);
         userService.join(user1);
 
         //when
-        User user2 = make_Nth_User(2);
+        UserDTO user2 = make_Nth_User(2);
         user2.setUserEmail(user1.getUserEmail());
 
         //then
@@ -103,11 +103,11 @@ public class UserControllerTest {
     @Transactional
     public void 일반DB_회원가입_테스트() throws Exception{
         //given
-        User user1 = make_Nth_User(1);
+        UserDTO user1 = make_Nth_User(1);
         userService.join(user1);
 
         //when
-        User user2 = make_Nth_User(2);
+        UserDTO user2 = make_Nth_User(2);
 
         //then
         mockMvc.perform(post(HttpConst.USER_URI)
@@ -121,11 +121,11 @@ public class UserControllerTest {
     public void 회원정보_수정_inWeb() throws Exception{
 
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long savedIndex = userService.join(user);
 
         //when
-        User modifiedUser = make_Nth_User(1);
+        UserDTO modifiedUser = make_Nth_User(1);
         modifiedUser.setUserIdx(savedIndex);
         modifiedUser.setUserEmail("newEmail");
 
@@ -143,11 +143,11 @@ public class UserControllerTest {
     @Transactional
     public void 회원Id는_변경할수_없습니다() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long savedIndex = userService.join(user);
 
         //when
-        User modifiedUser = make_Nth_User(1);
+        UserDTO modifiedUser = make_Nth_User(1);
         modifiedUser.setUserIdx(savedIndex);
         modifiedUser.setUserId("newId");
 
@@ -163,24 +163,25 @@ public class UserControllerTest {
     @Transactional
     public void 회원탈퇴_성공_테스트() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long savedIdx = userService.join(user);
 
         //when
-        User deleteUser = make_Nth_User(1);
+        UserDTO deleteUser = make_Nth_User(1);
         deleteUser.setUserIdx(savedIdx);
-        deleteUser.setActive(false);
 
         //then
 
         mockMvc.perform(delete(HttpConst.USER_URI)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(user)))
+                        .content(objectMapper.writeValueAsString(deleteUser)))
                 .andExpect(status().isOk());
         Assertions.assertThat(userService.findUserByIndex(savedIdx)
                         .isActive())
                 .isFalse();
     }
+
+
    /* @Test
     public void 존재하지_않는_회원_변경() throws Exception{
         //given
@@ -219,8 +220,8 @@ public class UserControllerTest {
                 .andExpect(header().string(HttpConst.HEADER_NAME_ERROR_MESSAGE, HttpConst.UNREGISTER_USER_MESSAGE));
     }*/
 
-    private User make_Nth_User(int N){
-        User user = new User();
+    private UserDTO make_Nth_User(int N){
+        UserDTO user = new UserDTO();
         user.setUserName("user" + N + "name");
         user.setUserId("user" + N + "Id");
         user.setUserEmail("user" + N + "Email");

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
@@ -56,10 +56,10 @@ public class UserServiceTest {
 
         //then
         User newUser = new User();
-        user.setUserId("sameId");
-        user.setUserName("user1Name");
-        user.setUserPassword("user1Password");
-        user.setUserEmail("user1Email");
+        newUser.setUserId("sameId");
+        newUser.setUserName("user1Name");
+        newUser.setUserPassword("user1Password");
+        newUser.setUserEmail("user1Email");
 
         userService.join(newUser);
     }

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
@@ -2,9 +2,11 @@
 package com.example.tumblbugclone.service;
 
 import com.example.tumblbugclone.Exception.userexception.UserCantModifyIdException;
+import com.example.tumblbugclone.Exception.userexception.UserDTOConvertException;
 import com.example.tumblbugclone.Exception.userexception.UserEmailDuplicatedException;
 import com.example.tumblbugclone.Exception.userexception.UserIdDuplicatedException;
 
+import com.example.tumblbugclone.dto.UserDTO;
 import com.example.tumblbugclone.model.User;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -27,25 +29,25 @@ public class UserServiceTest {
     @Transactional
     public void 회원가입() throws Exception{
         //given
-        User user = new User();
+        UserDTO user = new UserDTO();
         user.setUserId("userId");
         user.setUserName("userName");
         user.setUserPassword("userPassword");
         user.setUserEmail("userEmail");
 
         //when
-        userService.join(user);
+        long userIdx = userService.join(user);
 
         //then
-        Assertions.assertThat(user.getUserIdx()).isNotEqualTo(0);
+        Assertions.assertThat(userService.findUserByIndex(userIdx).getUserIdx()).isNotEqualTo(0);
     }
 
 
     @Test(expected = UserIdDuplicatedException.class)
     @Transactional
-    public void Id가_중복되면_Exception() throws UserEmailDuplicatedException, UserIdDuplicatedException {
+    public void Id가_중복되면_Exception() throws UserEmailDuplicatedException, UserIdDuplicatedException, UserDTOConvertException {
         //given
-        User user = new User();
+        UserDTO user = new UserDTO();
         user.setUserId("sameId");
         user.setUserName("userName");
         user.setUserPassword("userPassword");
@@ -55,7 +57,7 @@ public class UserServiceTest {
         userService.join(user);
 
         //then
-        User newUser = new User();
+        UserDTO newUser = new UserDTO();
         newUser.setUserId("sameId");
         newUser.setUserName("user1Name");
         newUser.setUserPassword("user1Password");
@@ -64,11 +66,11 @@ public class UserServiceTest {
         userService.join(newUser);
     }
 
-    @Test(expected = DataIntegrityViolationException.class)
+    @Test(expected = UserEmailDuplicatedException.class)
     @Transactional
     public void Emial이_중복되면_Exception() throws Exception{
         //given
-        User user = new User();
+        UserDTO user = new UserDTO();
         user.setUserId("userId");
         user.setUserName("userName");
         user.setUserPassword("userPassword");
@@ -78,20 +80,20 @@ public class UserServiceTest {
         userService.join(user);
 
         //then
-        User newUser = new User();
-        user.setUserId("user1Id");
-        user.setUserName("user1Name");
-        user.setUserPassword("user1Password");
-        user.setUserEmail("sameEmail");
+        UserDTO newUser = new UserDTO();
+        newUser.setUserId("user1Id");
+        newUser.setUserName("user1Name");
+        newUser.setUserPassword("user1Password");
+        newUser.setUserEmail("sameEmail");
 
         userService.join(newUser);
     }
 
-    @Test(expected = DataIntegrityViolationException.class)
+    @Test(expected = UserDTOConvertException.class)
     @Transactional
     public void 회원_이름은_필수() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         user.setUserName(null);
 
         //when
@@ -100,11 +102,11 @@ public class UserServiceTest {
         //then
     }
 
-    @Test(expected = DataIntegrityViolationException.class)
+    @Test(expected = UserDTOConvertException.class)
     @Transactional
     public void 회원_Id는_필수() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         user.setUserId(null);
 
         //when
@@ -117,7 +119,7 @@ public class UserServiceTest {
     @Transactional
     public void 회원_비밀번호는_필수() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         user.setUserPassword(null);
 
         //when
@@ -126,11 +128,11 @@ public class UserServiceTest {
         //then
     }
 
-    @Test(expected = DataIntegrityViolationException.class)
+    @Test(expected = UserDTOConvertException.class)
     @Transactional
     public void 회원_Email은_필수() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         user.setUserEmail(null);
 
         //when
@@ -143,11 +145,11 @@ public class UserServiceTest {
     @Transactional
     public void Id로_회원_조회() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         userService.join(user);
 
         //when
-        User findByUserId = userService.findUserById(user.getUserId());
+        UserDTO findByUserId = userService.findUserById(user.getUserId());
 
         //then
         Assertions.assertThat(findByUserId.getUserEmail()).isEqualTo(user.getUserEmail());
@@ -158,11 +160,11 @@ public class UserServiceTest {
     @Transactional
     public void Index로_회원_조회() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long userIndex = userService.join(user);
 
         //when
-        User findUserBuIndex = userService.findUserByIndex(userIndex);
+        UserDTO findUserBuIndex = userService.findUserByIndex(userIndex);
 
         //then
         Assertions.assertThat(user.getUserId()).isEqualTo(findUserBuIndex.getUserId());
@@ -173,12 +175,12 @@ public class UserServiceTest {
     @Transactional
     public void 같은_회원_두번_조회() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long savedIndex = userService.join(user);
 
         //when
-        User findByIndex = userService.findUserByIndex(savedIndex);
-        User findById = userService.findUserById(user.getUserId());
+        UserDTO findByIndex = userService.findUserByIndex(savedIndex);
+        UserDTO findById = userService.findUserById(user.getUserId());
 
         //then
         Assertions.assertThat(findById).isEqualTo(findByIndex);
@@ -188,11 +190,12 @@ public class UserServiceTest {
     @Transactional
     public void 회원_id는_수정불가() throws Exception{
         //given
-        User user = make_Nth_User(1);
-        userService.join(user);
+        UserDTO user = make_Nth_User(1);
+        long userIdx = userService.join(user);
+        user.setUserIdx(userIdx);
 
         //when
-        User modifyUser = make_Nth_User(1);
+        UserDTO modifyUser = make_Nth_User(1);
         modifyUser.setUserIdx(user.getUserIdx());
         modifyUser.setUserId("modifiedId");
 
@@ -204,12 +207,13 @@ public class UserServiceTest {
     @Transactional
     public void 회원_정보_수정성공() throws Exception{
         //given
-        User user = make_Nth_User(1);
-        userService.join(user);
+        UserDTO user = make_Nth_User(1);
+        long userIdx = userService.join(user);
+        user.setUserIdx(userIdx);
 
         //when
-        User modifyUser = make_Nth_User(1);
-        modifyUser.setUserIdx(user.getUserIdx());
+        UserDTO modifyUser = make_Nth_User(1);
+        modifyUser.setUserIdx(userIdx);
         modifyUser.setUserImg("newImageURL");
         modifyUser.setUserPassword("newPassword");
         modifyUser.setGreeting("Hi");
@@ -223,8 +227,9 @@ public class UserServiceTest {
     @Transactional
     public void 회원_탈퇴() throws Exception{
         //given
-        User user = make_Nth_User(1);
+        UserDTO user = make_Nth_User(1);
         long userIndex = userService.join(user);
+        user.setUserIdx(userIndex);
 
         //when
         userService.unregiste(user);
@@ -233,8 +238,8 @@ public class UserServiceTest {
         Assertions.assertThat(userService.findUserByIndex(userIndex).isActive()).isFalse();
     }
 
-    private User make_Nth_User(int n){
-        User user = new User();
+    private UserDTO make_Nth_User(int n){
+        UserDTO user = new UserDTO();
         String nString = Integer.toString(n);
         user.setUserId("user" + nString + "Id");
         user.setUserName("user" + nString + "Name");


### PR DESCRIPTION
## 이슈 번호 : #84 


## PR 유형
- feature 수정

## 작업 내용
- `DTO`-`Entity` 변환 위치를 `Controller` 클래스에서 `Service` 클래스로 변경

## 리뷰어가 집중해야 될 부분
- `Service` 클래스에서 `DTO` 객체를 사용하게 되면서, `Service`의 메서드가 반환하는 객체가 영속성 컨텍스트에서 관리되지 않게 변경 되었습니다. 그로 인해 test code 일부 수정되었습니다.
- `UserDTO` 객체를 반환할 경우 내부의 `password` 필드를 `null`로 설정해 두는 작업이 필요합니다. 

## 다음 작업 계획
- `Project` 리스트 컨트롤러 구현