### PR TITLE
feat#103 - 상세 페이지 헤더 뷰 제작 완료

### DIFF
--- a/frontend/src/ProjectDetail/SponsorInfo.tsx
+++ b/frontend/src/ProjectDetail/SponsorInfo.tsx
@@ -1,29 +1,64 @@
 import React from 'react';
 import "./sponsorInfo.scss";
+import { AiOutlineHeart, AiOutlineShareAlt } from "react-icons/ai";
+import { formatKoreanCurrency } from '../utils/commonFunction';
+
+interface sponsorInterface {
+    goalMoney: number,
+    sponsorMoney: number,
+    sposnorMember: number,
+    sponsorStartDate: Date,
+    sponsorEndDate: Date,
+    projectLike: number,
+    projectShare: number,
+}
 
 function SponsorInfo() {
+    const sponsorInfoObj: sponsorInterface = {
+        goalMoney: 3_000_000,
+        sponsorMoney: 51_176_000,
+        sposnorMember: 1_752,
+        sponsorStartDate: new Date(2023, 5, 8),
+        sponsorEndDate: new Date(2023, 6, 8),
+        projectLike: 3_140,
+        projectShare: 828,
+    }
+
     return (
         <section className="infoArea">
             <section className="mainBox">
                 <div className="sponsorMoneyRow">
                     <h4>모인 금액</h4>
-                    <h3><strong>51,176,000원</strong></h3>
-                    <h2>1705%</h2>
+                    <h3><strong>{formatKoreanCurrency(sponsorInfoObj.sponsorMoney)}</strong>원</h3>
+                    <h2>{Math.round(sponsorInfoObj.sponsorMoney / sponsorInfoObj.goalMoney) * 100}%</h2>
                 </div>
                 <div className="sponsorTimeRow">
                     <h4>남은 시간</h4>
-                    <h3>21일</h3>
+                    <h3><strong>21</strong>일</h3>
                 </div>
                 <div className="sponsorMemberRow">
                     <h4>후원자</h4>
-                    <h3><strong>1,752명</strong></h3>
+                    <h3><strong>{formatKoreanCurrency(sponsorInfoObj.sposnorMember)}</strong>명</h3>
                 </div>
             </section>
             <section className="subBox">
-                sub
+                <span>목표금액</span>
+                <span>${formatKoreanCurrency(sponsorInfoObj.goalMoney)}원</span>
+                <span>펀딩 기간</span>
+                <span>{sponsorInfoObj.sponsorStartDate.toDateString()} ~ {sponsorInfoObj.sponsorEndDate.toDateString()}<strong>20일 남음</strong></span>
+                <span>결제</span>
+                <span>목표 금액 달성시 2023.06.09에 결제 진행</span>
             </section>
             <section className="buttonBox">
-                button
+                <div className="buttonBox__heart">
+                    <AiOutlineHeart/>
+                    <span>{sponsorInfoObj.projectLike}</span>
+                </div>
+                <div className="buttonBox__share">
+                    <AiOutlineShareAlt/>
+                    <span>{sponsorInfoObj.projectShare}</span>
+                </div>
+                <button type="button">이 프로젝트 후원하기</button>
             </section>
         </section>
     )

--- a/frontend/src/ProjectDetail/sponsorInfo.scss
+++ b/frontend/src/ProjectDetail/sponsorInfo.scss
@@ -1,3 +1,5 @@
+$button-right-margin: 5%;
+
 .infoArea {
     width: 30%;
     height: 70%;
@@ -9,6 +11,9 @@
     & .mainBox {
         width: 100%;
         height: 60%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
 
         &:after {
             content: "";
@@ -19,17 +24,145 @@
             margin: 1px 0;
             background-color: rgba(0, 0, 0, 0.1);
         }
+
+        & .sponsorMoneyRow {
+            display: flex;
+            flex-wrap: wrap;
+
+            & h4 {
+                width: 100%;
+                font-size: 1rem;
+                margin-bottom: 2%;
+            }
+
+            & h3 {
+                font-size: 1.1rem;
+                margin-right: 5%;
+                align-self: flex-end;
+
+                & strong {
+                    align-self: center;
+                    font-size: 2rem;
+                    font-weight: 700;
+                }
+            }
+
+            & h2 {
+                align-self: flex-end;
+                font-size: 1.2rem;
+                font-weight: 700;
+            }
+        }
+
+        & .sponsorTimeRow {
+            display: flex;
+            flex-wrap: wrap;
+
+            & h4 {
+                width: 100%;
+                font-size: 1rem;
+                margin-bottom: 2%;
+            }
+
+            & h3 {
+                font-size: 1.1rem;
+                margin-right: 5%;
+                align-self: flex-end;
+
+                & strong {
+                    align-self: center;
+                    font-size: 2rem;
+                    font-weight: 700;
+                }
+            }
+        }
+
+        & .sponsorMemberRow {
+            display: flex;
+            flex-wrap: wrap;
+
+            & h4 {
+                width: 100%;
+                font-size: 1rem;
+                margin-bottom: 2%;
+            }
+
+            & h3 {
+                font-size: 1.1rem;
+                margin-right: 5%;
+                align-self: flex-end;
+
+                & strong {
+                    align-self: center;
+                    font-size: 2rem;
+                    font-weight: 700;
+                }
+            }
+        }
     }
 
     & .subBox {
         width: 100%;
-        height: 25%;
-        background-color: green;
+        height: 20%;
+        padding: 2.5% 0;
+        display: grid;
+        grid-template-columns: 1fr 3fr;
+        grid-template-rows: 1fr 1fr 1fr;
+        
+        & span {
+            font-size: 0.8rem;
+
+            &:nth-child(2n + 1) {
+                font-weight: 700;
+            }
+
+            & strong {
+                border-radius: 5px;
+                font-weight: 700;
+                font-size: 0.7rem;
+                padding: 1.5%;
+                color: rgb(255, 87, 87);
+                background-color: rgb(253, 244, 243);
+            }
+        }
     }
 
     & .buttonBox {
         width: 100%;
         height: 15%;
-        background-color: red;
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        
+        & .buttonBox__heart {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            margin-right: $button-right-margin;
+            width: 14.4%;
+            height: 80%;
+            outline: 1px solid rgba(0, 0, 0, 0.2);
+        }
+
+        & .buttonBox__share {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            margin-right: $button-right-margin;
+            width: 14.4%;
+            height: 80%;
+            outline: 1px solid rgba(0, 0, 0, 0.2);
+        }
+
+        & button {
+            width: 55%;
+            height: 80%;
+            color: #fff;
+            font-weight: 700;
+            font-size: 1rem;
+            background-color: rgb(250, 100, 98);
+        }
     }
 }


### PR DESCRIPTION
## 이슈 번호 : #103 상세 페이지 뷰 제작


## PR 유형
- feature 추가

## 작업 내용
- 상세 페이지 뷰 제작
<img width="1508" alt="상세 페이지 뷰" src="https://github.com/Start-as-Web-Developers/tumblbug-clone-coding/assets/74173976/31518b1c-9560-4fb4-891e-b462ee0cbbcf">

- 이미지 슬라이더 커스텀 제작

https://github.com/Start-as-Web-Developers/tumblbug-clone-coding/assets/74173976/db562faf-4ae1-40ed-b854-e715a0b001d0


## 리뷰어가 집중해야 될 부분
- 이미지 슬라이더 사용이 어렵다면 말씀해주세요
- 상세 페이지 아랫 부분 만드실 때 (후원 카드, 프로젝트 설명 영역) 헤더 부분과 너비를 잘 맞추어주세요

## 다음 작업 계획
- 태훈님과 의논 후 결정할 예정입니다.
