### PR TITLE
feat : #99 - complete update logic before using comment

### DIFF
--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/Exception/userexception/UnauthorizedUserException.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/Exception/userexception/UnauthorizedUserException.java
@@ -1,0 +1,10 @@
+package com.example.tumblbugclone.Exception.userexception;
+
+import com.example.tumblbugclone.Exception.TumblbugException;
+import com.example.tumblbugclone.managedconst.ExceptionConst;
+
+public class UnauthorizedUserException extends TumblbugException {
+    public UnauthorizedUserException() {
+        super(ExceptionConst.UnauthorizedUser);
+    }
+}

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UpdateController.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UpdateController.java
@@ -1,0 +1,120 @@
+package com.example.tumblbugclone.controller;
+
+import com.example.tumblbugclone.Exception.TumblbugException;
+import com.example.tumblbugclone.Exception.updateException.CantFindUpdateException;
+import com.example.tumblbugclone.Exception.updateException.UpdateCantModifyModifiedToFalse;
+import com.example.tumblbugclone.Exception.userexception.LoginRequiredException;
+import com.example.tumblbugclone.Exception.userexception.UserCantFindException;
+import com.example.tumblbugclone.dto.ProjectUpdateDTO;
+import com.example.tumblbugclone.managedconst.ExceptionConst;
+import com.example.tumblbugclone.managedconst.HttpConst;
+import com.example.tumblbugclone.service.ProjectUpdateService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping(HttpConst.UPDATE_URI)
+public class UpdateController {
+
+    ProjectUpdateService projectUpdateService;
+
+    @Autowired
+    public UpdateController(ProjectUpdateService projectUpdateService){
+        this.projectUpdateService = projectUpdateService;
+    }
+
+    @GetMapping
+    public ResponseEntity findUpdates(@PathVariable("project-id")long projectId){
+
+        List<ProjectUpdateDTO> updates;
+        try {
+            updates = projectUpdateService.findUpdateList(projectId);
+        } catch (TumblbugException e) {
+            return ResponseEntity.status(e.getErrorStatus()).build();
+        }
+
+        return ResponseEntity.ok().body(updates);
+    }
+
+    @PostMapping()
+    public ResponseEntity save(@PathVariable("project-id")long projectId, @RequestBody String updateContent, HttpSession session){
+        if(session.isNew()){
+            return ResponseEntity
+                    .status(ExceptionConst.LoginRequiredStatus)
+                    .build();
+        }
+
+        long userIndex = (long) session.getAttribute(HttpConst.SESSION_USER_INDEX);
+        long updateIndex;
+
+        try {
+            updateIndex = projectUpdateService.save(userIndex, projectId, updateContent);
+        } catch (TumblbugException e) {
+            return ResponseEntity.status(e.getErrorStatus()).build();
+        }
+
+        return ResponseEntity.ok().body(Long.toString(updateIndex));
+    }
+
+    @GetMapping(HttpConst.UPDATE_ID)
+    public ResponseEntity<ProjectUpdateDTO> findUpdate(@PathVariable("project-id")long projectId, @PathVariable("update-id")long updateId) {
+        ProjectUpdateDTO projectUpdateDTO;
+        try {
+            projectUpdateDTO = projectUpdateService.findProjectUpdateDTO(updateId);
+        } catch (TumblbugException e) {
+            return ResponseEntity.status(e.getErrorStatus()).build();
+        }
+
+        if(projectId != projectUpdateDTO.getProjectId())
+            return ResponseEntity.status(ExceptionConst.NotMatchProjectId).build();
+
+        System.out.println(projectUpdateDTO);
+        return ResponseEntity.ok()
+                .body(projectUpdateDTO);
+    }
+
+    @PatchMapping(HttpConst.UPDATE_ID)
+    public ResponseEntity<ProjectUpdateDTO> modifyUpdate(
+            @PathVariable("update-id")long updateId, @RequestBody String newContent, HttpSession session){
+
+        long userIdx;
+        if(session.isNew()){
+            return ResponseEntity.status(ExceptionConst.LoginRequiredStatus).build();
+        }
+        userIdx = (long)session.getAttribute(HttpConst.SESSION_USER_INDEX);
+
+        ProjectUpdateDTO updateDTO;
+        try {
+            updateDTO = projectUpdateService.update(userIdx, updateId, newContent);
+        } catch (TumblbugException e) {
+            return ResponseEntity.status(e.getErrorStatus()).build();
+        }
+
+        return ResponseEntity.ok()
+                .body(updateDTO);
+    }
+
+    @DeleteMapping(HttpConst.UPDATE_ID)
+    public ResponseEntity deleteUpdate( @PathVariable("update-id")long updateId, HttpSession session){
+        long userIdx;
+        if(session.isNew()){
+            return ResponseEntity.status(ExceptionConst.LoginRequiredStatus).build();
+        }
+        userIdx = (long)session.getAttribute(HttpConst.SESSION_USER_INDEX);
+
+        try {
+            projectUpdateService.delete(userIdx, updateId);
+        }catch (TumblbugException e){
+            return ResponseEntity.status(e.getErrorStatus()).build();
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+
+}

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UserController.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
     public ResponseEntity getUser(HttpSession session) {
         long userIndex = (long)session.getAttribute(HttpConst.SESSION_USER_INDEX);
 
-        UserSendingDTO userByIndex = userService.findUserByIndex(userIndex);
+        UserSendingDTO userByIndex = userService.findSendingUserByIndex(userIndex);
 
         return ResponseEntity.ok()
                 .body(userByIndex);
@@ -40,7 +40,7 @@ public class UserController {
     @GetMapping("/{userIdx}")
     public ResponseEntity checkUser(@PathVariable String userIdx) {
 
-        UserSendingDTO userByIndex = userService.findUserByIndex(Long.parseLong(userIdx));
+        UserSendingDTO userByIndex = userService.findSendingUserByIndex(Long.parseLong(userIdx));
 
 
         return ResponseEntity.ok()
@@ -105,7 +105,7 @@ public class UserController {
     }
 
 
-    @GetMapping(HttpConst.USER_LOGIN_URL)
+    @GetMapping(HttpConst.USER_LOGIN_URI)
     public ResponseEntity login(@RequestBody UserLoginDTO loginDTO, HttpSession session) {
         long loginUserIndex;
         try {
@@ -121,7 +121,7 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping(HttpConst.USER_LOGOUT_URL)
+    @GetMapping(HttpConst.USER_LOGOUT_URI)
     public ResponseEntity logout(HttpServletRequest request){
         HttpSession session = request.getSession(false);
         if(session == null){

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/dto/ProjectUpdateDTO.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/dto/ProjectUpdateDTO.java
@@ -14,7 +14,7 @@ public class ProjectUpdateDTO {
 
     long id;
     String content;
-    String createrName;
+    UserSendingDTO creater;
     long projectId;
     Date updateDate;
     boolean modified = false;

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/managedconst/ExceptionConst.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/managedconst/ExceptionConst.java
@@ -9,6 +9,7 @@ public class ExceptionConst { //Tumblbug 내부에 작성하는 것이 좋았을
     public static final int UserIdDuplicatedStatus = 415;
     public static final int WrongPasswordStatus = 416;
     public static final int LoginRequiredStatus = 417;
+    public static final int UnauthorizedUser = 418;
 
     //== Project card const ==//
     public static final int StartIndexStatus = 421;
@@ -17,4 +18,5 @@ public class ExceptionConst { //Tumblbug 내부에 작성하는 것이 좋았을
     public static final int UpdateCantModifyId = 631;
     public static final int UpdateCantModifyModifiedToFalse = 632;
     public static final int CantFindUpdate = 633;
+    public static final int NotMatchProjectId = 634;
 }

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/managedconst/HttpConst.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/managedconst/HttpConst.java
@@ -4,13 +4,18 @@ public class HttpConst {
     //==MAIN URL ==//
     public static final String USER_URI = "/user";
     public static final String USER_SIGNUP_URI = "/signup";
-    public static final String USER_LOGIN_URL = "/login";
-    public static final String USER_LOGOUT_URL = "/logout";
+    public static final String USER_LOGIN_URI = "/login";
+    public static final String USER_LOGOUT_URI = "/logout";
+
     public static final String PROJECT_URI = "/project";
     public static final String COMMUNITY_URI = "/project/{project-id}/community";
     public static final String PROJECT_LIST_URI = "/projects";
     public static final String PRODUCT_URI = "/project/{project-id}/product";
     public static final String COMPONENT_URI = "/product/{product-id}/component";
+
+    public static final String UPDATE_URI = PROJECT_URI + "/{project-id}/update";
+    public static final String UPDATE_ID = "/{update-id}";
+
 
     //== method URL ==//
     public static final String ON_GOING = "/ongoing";

--- a/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
+++ b/backend/tumblbug-clone/src/main/java/com/example/tumblbugclone/service/UserService.java
@@ -42,13 +42,16 @@ public class UserService {
     }
 
 
-    public UserSendingDTO findUserByIndex(long userIdx){
+    public UserSendingDTO findSendingUserByIndex(long userIdx){
 
         User findUser = userRepository.findUserByIndex(userIdx);
 
         return convertUser2DTO(findUser);
     }
 
+    public User findUserByIndex(long userIdx){
+        return userRepository.findUserByIndex(userIdx);
+    }
 
     public UserSendingDTO findUserById(String userId){
 

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UpdateControllerTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UpdateControllerTest.java
@@ -1,0 +1,506 @@
+package com.example.tumblbugclone.controller;
+
+import com.example.tumblbugclone.dto.ProjectUpdateDTO;
+import com.example.tumblbugclone.managedconst.ExceptionConst;
+import com.example.tumblbugclone.managedconst.HttpConst;
+import com.example.tumblbugclone.model.Project;
+import com.example.tumblbugclone.model.User;
+import com.example.tumblbugclone.repository.ProjectRepository;
+import com.example.tumblbugclone.repository.UserRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoSession;
+import org.mockito.internal.framework.DefaultMockitoSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = "classpath:appConfig.xml")
+@WebMvcTest
+@AutoConfigureMockMvc
+public class UpdateControllerTest {
+
+    @Autowired UpdateController updateController;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @Transactional
+    public void update_저장() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+        String url = HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId));
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        //when
+
+        //then
+        mockMvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("Project Update")
+                        .session(session))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Transactional
+    public void 세션_없이_update_저장() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+        String url = HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId));
+
+
+        //when
+
+        //then
+        mockMvc.perform(post(url)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content("ProjectUpdate"))
+                .andExpect(status().is(ExceptionConst.LoginRequiredStatus));
+    }
+
+    @Test
+    @Transactional
+    public void 존재하지_않는_회원이_update_저장() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+        String url = HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId));
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex+1);
+
+        //when
+
+        //then
+        mockMvc.perform(post(url)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andExpect(status().is(ExceptionConst.UserCantFindStatus));
+    }
+
+    @Test
+    @Transactional
+    public void update_조회() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+        String content = "Content";
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(content)
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        mvcResult = mockMvc.perform(get((HttpConst.UPDATE_URI+HttpConst.UPDATE_ID)
+                        .replace("{project-id}", Long.toString(projectId))
+                        .replace("{update-id}", Long.toString(updateIndex))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        ProjectUpdateDTO findDTO = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ProjectUpdateDTO.class);
+
+        //then
+        Assertions.assertThat(findDTO.getId()).isEqualTo(updateIndex);
+        Assertions.assertThat(findDTO.getContent()).isEqualTo(content);
+        Assertions.assertThat(findDTO.getCreater().getUserIdx()).isEqualTo(userIndex);
+    }
+
+    @Test
+    @Transactional
+    public void 없는_update_조회() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        mockMvc.perform(get((HttpConst.UPDATE_URI+HttpConst.UPDATE_ID)
+                        .replace("{project-id}", Long.toString(projectId))
+                        .replace("{update-id}", Long.toString(updateIndex+1))))
+                .andExpect(status().is(ExceptionConst.CantFindUpdate));
+    }
+
+    @Test
+    @Transactional
+    public void 잘못된_projectId로_update_단건조회() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        mockMvc.perform(get((HttpConst.UPDATE_URI+HttpConst.UPDATE_ID)
+                        .replace("{project-id}", Long.toString(projectId+1))
+                        .replace("{update-id}", Long.toString(updateIndex))))
+                .andExpect(status().is(ExceptionConst.NotMatchProjectId));
+    }
+
+    @Test
+    @Transactional
+    public void update_수정성공() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String modifyContent = "Modify content";
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        MvcResult modifiedResult = mockMvc.perform(patch(updateURL)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(modifyContent)
+                        .session(session))
+                .andExpect(status().isOk()).andReturn();
+        ProjectUpdateDTO modifiedDTO = objectMapper.readValue(modifiedResult.getResponse().getContentAsString(), ProjectUpdateDTO.class);
+
+        MvcResult findResult = mockMvc.perform(get(updateURL))
+                .andExpect(status().isOk()).andReturn();
+        ProjectUpdateDTO findDTO = objectMapper.readValue(findResult.getResponse().getContentAsString(), ProjectUpdateDTO.class);
+
+        //then
+
+        Assertions.assertThat(modifiedDTO.getContent()).isEqualTo(modifyContent);
+        Assertions.assertThat(modifiedDTO).isEqualTo(findDTO);
+    }
+
+    @Test
+    @Transactional
+    public void 잘못된_권한_update_수정() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String modifyContent = "Modify content";
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex+1);
+        mockMvc.perform(patch(updateURL)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(modifyContent)
+                        .session(session))
+                .andExpect(status().is(ExceptionConst.UnauthorizedUser));
+    }
+
+    @Test
+    @Transactional
+    public void 세션없이_update_수정() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String modifyContent = "Modify content";
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        mockMvc.perform(patch(updateURL)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(modifyContent))
+                .andExpect(status().is(ExceptionConst.LoginRequiredStatus));
+    }
+
+    @Test
+    @Transactional
+    public void update_삭제() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+        mockMvc.perform(delete(updateURL)
+                        .session(session))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get(updateURL))
+                .andExpect(status().is(ExceptionConst.CantFindUpdate));
+    }
+
+    @Test
+    @Transactional
+    public void 세션_없이_update_삭제() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+        mockMvc.perform(delete(updateURL))
+                .andExpect(status().is(ExceptionConst.LoginRequiredStatus));
+    }
+
+    @Test
+    @Transactional
+    public void 잘못된_권한_update_삭제() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        MvcResult mvcResult = mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .content(" ")
+                        .session(session))
+                .andReturn();
+        long updateIndex = Long.parseLong(mvcResult.getResponse().getContentAsString());
+
+        //when
+        String updateURL = (HttpConst.UPDATE_URI + HttpConst.UPDATE_ID)
+                .replace("{project-id}", Long.toString(projectId))
+                .replace("{update-id}", Long.toString(updateIndex));
+
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex+1);
+        mockMvc.perform(delete(updateURL)
+                        .session(session))
+                .andExpect(status().is(ExceptionConst.UnauthorizedUser));
+    }
+
+    @Test
+    @Transactional
+    public void updateList_조회() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+        for(int i = 0; i<3; i++) {
+            mockMvc.perform(post(HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId)))
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content(" ")
+                            .session(session))
+                    .andReturn();
+        }
+
+        //when
+        String listUrl = HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId));
+
+        MvcResult listResult = mockMvc.perform(get(listUrl))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        List<ProjectUpdateDTO> updateDTOS = objectMapper.readValue(listResult.getResponse().getContentAsString(), new TypeReference<List<ProjectUpdateDTO>>() {});
+
+        //then
+        Assertions.assertThat(updateDTOS.size()).isEqualTo(3);
+        for (int i = 0; i < 3; i++) {
+            Assertions.assertThat(updateDTOS.get(i).getProjectId()).isEqualTo(projectId);
+        }
+    }
+
+    @Test
+    @Transactional
+    public void 빈_updateList_조회() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIndex = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(HttpConst.SESSION_USER_INDEX, userIndex);
+
+
+        //when
+        String listUrl = HttpConst.UPDATE_URI.replace("{project-id}", Long.toString(projectId));
+
+        mockMvc.perform(get(listUrl))
+                .andExpect(status().is(ExceptionConst.CantFindUpdate));
+    }
+
+    private User makeNthUser(int i){
+        User user = new User();
+        user.setUserId("user" + i + "Id");
+        user.setUserName("user" +
+                i + "Name");
+        user.setUserEmail("user" + i + "Email");
+        user.setUserPassword("user" + i + "Password");
+
+        return user;
+    }
+
+    private Project makeProject(User user) {
+        Project project = new Project();
+        project.setUser(user);
+        project.setTitle("title");
+        project.setProjectImg("img");
+        project.setCategory("category");
+        project.setComment("comment");
+        project.setGoalMoney(1000L);
+        project.setStartDate(new Date());
+        project.setEndDate(new Date());
+        project.setPlanIntro("planIntro");
+        project.setPlanBudget("planBudget");
+        project.setPlanSchedule("planSchedule");
+        project.setPlanTeam("planTeam");
+        project.setPlanExplain("planExplain");
+        project.setPlanGuide("planGuide");
+
+        return project;
+    }
+
+    private ProjectUpdateDTO makeUpdate(){
+        ProjectUpdateDTO update = new ProjectUpdateDTO();
+        update.setUpdateDate(new Date());
+        update.setModified(false);
+        update.setContent("");
+
+        return update;
+    }
+}

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UserControllerTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/controller/UserControllerTest.java
@@ -1,10 +1,8 @@
-/*
 package com.example.tumblbugclone.controller;
 import com.example.tumblbugclone.dto.UserLoginDTO;
 import com.example.tumblbugclone.dto.UserReceivingDTO;
 import com.example.tumblbugclone.managedconst.ExceptionConst;
 import com.example.tumblbugclone.managedconst.HttpConst;
-import com.example.tumblbugclone.managedconst.UserConst;
 import com.example.tumblbugclone.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
@@ -178,7 +176,7 @@ public class UserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(deleteUser)))
                 .andExpect(status().isOk());
-        Assertions.assertThat(userService.findUserByIndex(savedIdx)
+        Assertions.assertThat(userService.findSendingUserByIndex(savedIdx)
                         .isActive())
                 .isFalse();
     }
@@ -196,7 +194,7 @@ public class UserControllerTest {
         loginDTO.setUserPassword(user.getUserPassword());
 
         //then
-        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URL)
+        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URI)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginDTO)))
                 .andExpect(status().isOk());
@@ -215,7 +213,7 @@ public class UserControllerTest {
         loginDTO.setUserPassword(user.getUserPassword());
 
         //then
-        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URL)
+        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URI)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginDTO)))
                 .andExpect(status().is(ExceptionConst.UserCantFindStatus));
@@ -234,7 +232,7 @@ public class UserControllerTest {
         loginDTO.setUserPassword("WrongPassword");
 
         //then
-        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URL)
+        mockMvc.perform(get(HttpConst.USER_URI + HttpConst.USER_LOGIN_URI)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(loginDTO)))
                 .andExpect(status().is(ExceptionConst.WrongPasswordStatus));
@@ -252,4 +250,3 @@ public class UserControllerTest {
     }
 
 }
-*/

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/repository/ProjectUpdateRepositoryTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/repository/ProjectUpdateRepositoryTest.java
@@ -71,7 +71,7 @@ public class ProjectUpdateRepositoryTest {
         projectUpdateRepository.update(projectUpdate);
 
         //then
-        Assertions.assertThat(projectUpdateRepository.findById(projectId)
+        Assertions.assertThat(projectUpdateRepository.findById(updateId)
                         .getContent())
                 .isEqualTo(modifyString);
         Assertions.assertThat(projectUpdateRepository.findById(updateId)

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/ProjectUpdateServiceTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/ProjectUpdateServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.tumblbugclone.service;
 
 import com.example.tumblbugclone.Exception.updateException.CantFindUpdateException;
+import com.example.tumblbugclone.Exception.userexception.UnauthorizedUserException;
 import com.example.tumblbugclone.dto.ProjectUpdateDTO;
 import com.example.tumblbugclone.model.Project;
 import com.example.tumblbugclone.model.ProjectUpdate;
@@ -41,12 +42,12 @@ public class ProjectUpdateServiceTest {
         ProjectUpdateDTO dto = makeUpdate();
 
         //when
-        long updateId = projectUpdateService.save(userIndex, projectId, dto);
+        long updateId = projectUpdateService.save(userIndex, projectId, dto.getContent());
         ProjectUpdateDTO projectUpdateDTO = projectUpdateService.findProjectUpdateDTO(updateId);
 
         //then
         Assertions.assertThat(projectUpdateDTO.getContent()).isEqualTo(dto.getContent());
-        Assertions.assertThat(projectUpdateDTO.getCreaterName()).isEqualTo(user.getUserName());
+        Assertions.assertThat(projectUpdateDTO.getCreater().getUserName()).isEqualTo(user.getUserName());
         Assertions.assertThat(projectUpdateDTO.getProjectId()).isEqualTo(projectId);
     }
 
@@ -60,14 +61,14 @@ public class ProjectUpdateServiceTest {
         Project project = makeProject(user);
         long projectId = projectRepository.save(project);
         ProjectUpdateDTO dto = makeUpdate();
-        long updateId = projectUpdateService.save(userIndex, projectId, dto);
+        long updateId = projectUpdateService.save(userIndex, projectId, dto.getContent());
 
         //when
         ProjectUpdateDTO projectUpdateDTO = projectUpdateService.findProjectUpdateDTO(updateId);
 
         //then
         Assertions.assertThat(projectUpdateDTO
-                        .getCreaterName())
+                        .getCreater().getUserName())
                 .isEqualTo(user.getUserName());
         Assertions.assertThat(projectUpdateDTO
                         .getProjectId())
@@ -89,17 +90,34 @@ public class ProjectUpdateServiceTest {
         Project project = makeProject(user);
         long projectId = projectRepository.save(project);
         ProjectUpdateDTO update = makeUpdate();
-        long updateId = projectUpdateService.save(userIdx, projectId, update);
+        long updateId = projectUpdateService.save(userIdx, projectId, update.getContent());
 
         //when
-        ProjectUpdateDTO original = projectUpdateService.findProjectUpdateDTO(updateId);
-        original.setContent("Modified Content");
-        projectUpdateService.update(original);
+        String modifyString = "Modified Content";
+        projectUpdateService.update(userIdx, updateId, modifyString);
         ProjectUpdateDTO modifiedDTO = projectUpdateService.findProjectUpdateDTO(updateId);
 
         //then
         Assertions.assertThat(modifiedDTO.isModified()).isTrue();
-        Assertions.assertThat(modifiedDTO.getContent()).isEqualTo(original.getContent());
+        Assertions.assertThat(modifiedDTO.getContent()).isEqualTo(modifyString);
+    }
+
+    @Test(expected = UnauthorizedUserException.class)
+    @Transactional
+    public void 잘못된_권한으로_업데이트_수정() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIdx = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+        ProjectUpdateDTO update = makeUpdate();
+        long updateId = projectUpdateService.save(userIdx, projectId, update.getContent());
+
+        //when
+        String modifyString = "Modified Content";
+        projectUpdateService.update(userIdx+1, updateId, modifyString);
+
+        //then
     }
 
     @Test(expected = CantFindUpdateException.class)
@@ -111,15 +129,29 @@ public class ProjectUpdateServiceTest {
         Project project = makeProject(user);
         long projectId = projectRepository.save(project);
         ProjectUpdateDTO update = makeUpdate();
-        long updateId = projectUpdateService.save(userIdx, projectId, update);
+        long updateId = projectUpdateService.save(userIdx, projectId, update.getContent());
 
         //when
-        projectUpdateService.delete(updateId);
+        projectUpdateService.delete(userIdx, updateId);
 
         //then
         projectUpdateService.findProjectUpdateDTO(updateId);
     }
 
+    @Test(expected = UnauthorizedUserException.class)
+    @Transactional
+    public void 잘못된_권한_업데이트_삭제() throws Exception{
+        //given
+        User user = makeNthUser(1);
+        long userIdx = userRepository.save(user);
+        Project project = makeProject(user);
+        long projectId = projectRepository.save(project);
+        ProjectUpdateDTO update = makeUpdate();
+        long updateId = projectUpdateService.save(userIdx, projectId, update.getContent());
+
+        //when
+        projectUpdateService.delete(userIdx+1, updateId);
+    }
     @Test
     @Transactional
     public void 업데이트_목록_조회() throws Exception{
@@ -129,16 +161,16 @@ public class ProjectUpdateServiceTest {
         Project project = makeProject(user);
         long projectId = projectRepository.save(project);
         ProjectUpdateDTO update1 = makeUpdate();
-        long updateId1 = projectUpdateService.save(userIdx, projectId, update1);
+        long updateId1 = projectUpdateService.save(userIdx, projectId, update1.getContent());
         update1 = projectUpdateService.findProjectUpdateDTO(updateId1);
         ProjectUpdateDTO update2 = makeUpdate();
-        long updateId2 = projectUpdateService.save(userIdx, projectId, update2);
+        long updateId2 = projectUpdateService.save(userIdx, projectId, update2.getContent());
         update2 = projectUpdateService.findProjectUpdateDTO(updateId2);
         ProjectUpdateDTO update3 = makeUpdate();
-        long updateId3 = projectUpdateService.save(userIdx, projectId, update3);
+        long updateId3 = projectUpdateService.save(userIdx, projectId, update3.getContent());
         update3 = projectUpdateService.findProjectUpdateDTO(updateId3);
         ProjectUpdateDTO update4 = makeUpdate();
-        long updateId4 = projectUpdateService.save(userIdx, projectId, update4);
+        long updateId4 = projectUpdateService.save(userIdx, projectId, update4.getContent());
         update4 = projectUpdateService.findProjectUpdateDTO(updateId4);
 
         //when

--- a/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
+++ b/backend/tumblbug-clone/src/test/java/com/example/tumblbugclone/service/UserServiceTest.java
@@ -7,21 +7,17 @@ import com.example.tumblbugclone.Exception.userexception.*;
 import com.example.tumblbugclone.dto.UserLoginDTO;
 import com.example.tumblbugclone.dto.UserReceivingDTO;
 import com.example.tumblbugclone.dto.UserSendingDTO;
-import com.example.tumblbugclone.managedconst.HttpConst;
 import jakarta.servlet.http.HttpSession;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 
@@ -47,7 +43,7 @@ public class UserServiceTest {
         long userIdx = userService.join(user);
 
         //then
-        Assertions.assertThat(userService.findUserByIndex(userIdx).getUserIdx()).isNotEqualTo(0);
+        Assertions.assertThat(userService.findSendingUserByIndex(userIdx).getUserIdx()).isNotEqualTo(0);
     }
 
 
@@ -187,7 +183,7 @@ public class UserServiceTest {
         System.out.println(userIndex);
 
         //when
-        UserSendingDTO findUserBuIndex = userService.findUserByIndex(userIndex);
+        UserSendingDTO findUserBuIndex = userService.findSendingUserByIndex(userIndex);
 
 
         //then
@@ -204,7 +200,7 @@ public class UserServiceTest {
         long savedIndex = userService.join(user);
 
         //when
-        UserSendingDTO findByIndex = userService.findUserByIndex(savedIndex);
+        UserSendingDTO findByIndex = userService.findSendingUserByIndex(savedIndex);
         UserSendingDTO findById = userService.findUserById(user.getUserId());
 
 
@@ -251,7 +247,7 @@ public class UserServiceTest {
         userService.modify(modifyUser);
 
         //then
-        UserSendingDTO findUser = userService.findUserByIndex(user.getUserIdx());
+        UserSendingDTO findUser = userService.findSendingUserByIndex(user.getUserIdx());
         modifyUser.setLastLogin(findUser.getLastLogin());
             //new Date()와 DB에서 조회한 Date의 표현 포멧이 달라 임시로 구현
         Assertions.assertThat(findUser).isEqualTo(modifyUser);
@@ -271,7 +267,7 @@ public class UserServiceTest {
         userService.unregiste(user);
 
         //then
-        Assertions.assertThat(userService.findUserByIndex(userIndex).isActive()).isFalse();
+        Assertions.assertThat(userService.findSendingUserByIndex(userIndex).isActive()).isFalse();
     }
 
 


### PR DESCRIPTION
## 이슈 번호 : #99 


## PR 유형
- feature 추가

## 작업 내용
- 내용 작성

## 리뷰어가 집중해야 될 부분
- 로그인이 필요한 기능에 대해서는 `UserController`에서 생성해 준 `HttpSession`을 사용합니다.
- `List<ProjectUpdateDTO>`를 반환하는 `findUpdates()` 메서드는 `update` 게시글이 존재하지 않을 때 633 상태코드를 반환합니다.
  - 프론트엔드에서 해당 부분에 대한 예외 처리가 필요합니다.
- `Update` 글 작성 성공에 대해선 생성된 글의 id를 반환합니다.
  - FE에서 해당 id 값을 사용해 redirection이 필요합니다.

## 다음 작업 계획
- 댓글 관련 기능 구현